### PR TITLE
docs: add GitHub Actions status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Haili Stock Style
 
+[![Daily Haili backtest](https://github.com/Yushcheng777/Haili-stock-style/actions/workflows/daily-haili.yml/badge.svg?branch=main)](https://github.com/Yushcheng777/Haili-stock-style/actions/workflows/daily-haili.yml)
+
 This repository contains the implementation of the Haili Style strategy.
 
 ## Features


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CI status badge at the top of the README linking to the daily backtest workflow so CI health is visible at a glance.
  * Inserted a blank line after the badge to preserve layout.
  * No changes to product behavior, API, or runtime.
  * Documentation now highlights automation health more prominently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->