### PR TITLE
fix(ci): upgrade workflow to Python 3.11 to satisfy akshare deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: |
+          python - <<'PY'
+          import sys, akshare
+          print("Python:", sys.version)
+          print("akshare:", akshare.__version__)
+          PY


### PR DESCRIPTION
将 Actions 的 Python 版本从 3.8 升至 3.11（或增加 3.10/3.11 矩阵） 原因：akshare 1.17.35 依赖 aiohttp>=3.11.13，aiohttp 3.11.x 不提供 Python 3.8 的发行版，导致安装失败 增加 pip 缓存，缩短安装时间
添加最小 smoke test，确保 akshare 可成功导入并输出版本