### PR TITLE
fix(ci): bump akshare from 1.13.82 to 1.17.35

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-akshare==1.13.82
-pandas==2.0.0
-matplotlib==3.7.0
-pytest
+akshare>=1.16.72,<2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Relaxed dependency constraints to allow Akshare versions >=1.16.72 and <2, improving compatibility with newer releases.
  * Removed strict pins for pandas, matplotlib, and pytest to reduce installation conflicts and provide more flexible environment setups.
  * Streamlines dependency management with a simplified requirements list.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->