### PR TITLE
Save backtest results to results branch & add scheduled backtests

### DIFF
--- a/.github/workflows/auto-respond.yml
+++ b/.github/workflows/auto-respond.yml
@@ -1,0 +1,25 @@
+﻿name: Auto-respond to new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-comment on new issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.issue;
+            const body = `感谢你提交 issue！为帮助我们更快定位并复现问题/需求，请补充下列信息（如适用）：
+
+- 策略名称 / 模块：
+- 回测时间区间 / 历史数据范围：
+- 复现步骤或示例（最好附上重现代码片段）：
+- 期望行为与实际表现：
+
+我会尽快阅读并回复。`;
+            await github.rest.issues.createComment({ ...issue, body });

--- a/.github/workflows/scheduled-backtest.yml
+++ b/.github/workflows/scheduled-backtest.yml
@@ -1,0 +1,60 @@
+﻿name: Scheduled backtests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run-backtests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Prepare timestamp
+        id: ts
+        run: echo "timestamp=$(date -u +%Y%m%dT%H%M%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Run backtests
+        run: |
+          TIMESTAMP=${{ steps.ts.outputs.timestamp }}
+          mkdir -p results/$TIMESTAMP
+          # Replace with your backtest entry script and args
+          python -u scripts/run_all_backtests.py --out results/$TIMESTAMP || true
+
+      - name: Commit results to results branch
+        env:
+          TIMESTAMP: ${{ steps.ts.outputs.timestamp }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B results
+          git add results/$TIMESTAMP
+          git commit -m "Backtest results: $TIMESTAMP" || echo "No changes to commit"
+          git push origin results --force
+
+      - name: Upload backtest artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backtest-results-${{ steps.ts.outputs.timestamp }}
+          path: results/${{ steps.ts.outputs.timestamp }}
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -1,69 +1,23 @@
-# Haili-stock-style
+﻿# 仓库精简说明
 
-This repository contains `haili_strategy.py`, a stock selection script using akshare with technical and funds filters.
+目标：本仓库仅保留策略代码、回测（backtest）相关逻辑、说明文档，并且通过 GitHub Actions 定时执行回测、保存结果以及对新 issue 自动回复。
 
-## New API: programmatic usage
+推荐目录结构：
+- strategies/          # 策略代码（你的交易策略）
+- backtests/           # 回测相关代码与配置（或把回测脚本放在 scripts/）
+- scripts/             # 辅助脚本，例如 run_all_backtests.py
+- docs/                # 文档（说明、使用方法）
+- results/             # （由 CI 写入到 results 分支，用于存放历史回测产物）
+- .github/workflows/   # workflow（定时回测、自动回复等）
+- requirements.txt
+- README.md
 
-`haili_style_selection(current_positions=None)`
+如何运行（本地）：
+1. 安装依赖： pip install -r requirements.txt
+2. 运行回测（示例）： python scripts/run_all_backtests.py --out results/local-YYYYmmddTHHMMSS
 
-- The function accepts an optional dictionary `current_positions` mapping stock code (string, keep leading zeros) to current position percentage (float, 0-100).
-- If `current_positions` is provided, the function uses it directly and will provide specific suggestions (建议下单方向, 建议调整(%), 交易指令_有仓_具体) for each stock based on the current holding.
-- If `current_positions` is `None`, the function falls back to trying to read `current_positions.csv` in the repository root (if present) or operates without exact current holdings and only outputs generic suggestions.
+CI（定时回测）：
+- 已添加 .github/workflows/scheduled-backtest.yml，会按计划运行回测并将结果推送到 `results` 分支，同时上传 artifact 供短期查看。
 
-### CSV format supported
-
-The script supports two CSV column formats for `current_positions.csv`:
-
-- Chinese headers (recommended):
-
-```
-代码,当前仓位(%)
-000001,20
-600000,0
-```
-
-- English headers:
-
-```
-code,current_pos
-000001,20
-600000,0
-```
-
-Make sure stock codes are strings with leading zeros preserved.
-
-### Usage examples
-
-- Programmatic (library) usage:
-
-```python
-from haili_strategy import haili_style_selection
-# pass current positions as a dict
-haili_style_selection(current_positions={"000001": 20, "600000": 0})
-```
-
-- CLI / script usage:
-
-If `current_positions.csv` exists in the project root, running the script will read it and produce concrete suggestions:
-
-```bash
-python haili_strategy.py
-```
-
-Output: `candidates_haili_style.csv` (UTF-8-sig) with columns including:
-- 代码, 名称, 总市值(亿), action_score, 目标仓位(%), 当前仓位(%), 交易指令_空仓, 交易指令_有仓, 交易指令_有仓_具体, 建议下单方向, 建议调整(%), 触发理由
-
-## Tests
-
-A simple pytest test is provided at `tests/test_haili_strategy.py`. The test monkeypatches `akshare` calls used by the script to provide deterministic data, so the test can run offline.
-
-Run tests with:
-
-```bash
-pip install -r requirements.txt   # ensure pytest and pandas installed
-pytest -q
-```
-
-## Example script
-
-An example script `examples/run_with_positions.py` demonstrates how to call the function from other code and pass a `current_positions` dictionary.
+安全注意：
+- 在将结果 commit 到仓库前，请确认结果文件不会包含大文件或敏感信息；对于很大的产物（数百 MB 以上），推荐上传到外部对象存储并在仓库保留 summary/metadata。


### PR DESCRIPTION

新增 .github/workflows/scheduled-backtest.yml：定时（和手动）运行回测、把输出写入 results/<timestamp> 并推送到独立分支 results，同时上传 artifact 供短期查看。
新增 .github/workflows/auto-respond.yml：当有人新建 issue 时自动回复并请求补充必要信息。
更新 README.md：说明仓库精简后的结构与 CI 行为。